### PR TITLE
disable typing notifications

### DIFF
--- a/keybase.py
+++ b/keybase.py
@@ -102,6 +102,13 @@ def setup(config):
         print >> sys.stderr, "Run `keybase logout` to log them out."
         sys.exit(1)
 
+
+    # Disable typing notifications
+    try:
+        subprocess.check_call(['keybase', 'chat', 'notification-settings', '--disable-typing'])
+    except subprocess.CalledProcessError as e:
+        print >> sys.stderr, "Error during disabling typing notifications", e.message
+
     if config.debug_team and config.debug_topic:
         try:
             call("read", {"options": {"channel": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ argparse
 configparser
 dateparser
 mock
+nltk


### PR DESCRIPTION
this could also just be run once to set the global setting, but if someone else spins up the bot they will have this config.

when starting the service you should add `--enable-bot-lite-mode` to disable some non-critical background services